### PR TITLE
Delete attributes from a model if they're set to `false`

### DIFF
--- a/lib/validate-model-def.js
+++ b/lib/validate-model-def.js
@@ -158,6 +158,12 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
   // Loop through and normalize each attribute in the model.
   _.each(normalizedModelDef.attributes, function updateProperties (val, attributeName) {
 
+    // If an attribute is set to `false`, delete it from the model.
+    if (val === false) {
+      delete normalizedModelDef.attributes[attributeName];
+      return;
+    }
+
     //  ┬ ┬┌─┐┌┐┌┌┬┐┬  ┌─┐  ┬┌┐┌┌─┐┌┬┐┌─┐┌┐┌┌─┐┌─┐  ┌┬┐┌─┐┌┬┐┬ ┬┌─┐┌┬┐┌─┐
     //  ├─┤├─┤│││ │││  ├┤   ││││└─┐ │ ├─┤││││  ├┤   │││├┤  │ ├─┤│ │ ││└─┐
     //  ┴ ┴┴ ┴┘└┘─┴┘┴─┘└─┘  ┴┘└┘└─┘ ┴ ┴ ┴┘└┘└─┘└─┘  ┴ ┴└─┘ ┴ ┴ ┴└─┘─┴┘└─┘


### PR DESCRIPTION
This happens before Waterline is instantiated, so the attribute will not appear on the "finished" model in the Sails app.