### PR TITLE
Update order & phrasing of choices for the automigrations prompt

### DIFF
--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -317,9 +317,9 @@ module.exports = function initialize(hook, sails, done){
         'In a production environment (NODE_ENV==="production") Sails always uses'+'\n',
         'migrate:"safe" to protect against inadvertent deletion of your data.\n',
         'However during development, you have a few other options for convenience:'+'\n\n',
-        '1. '+chalk.bold.cyan('safe')+'  - never auto-migrate my database(s). I will do it myself (for production)','\n',
-        '2. '+chalk.bold.yellow('alter')+' - wipe/drop and attempt to re-insert ALL my data (for development)\n',
-        '3. '+chalk.bold.red('drop')+'  - wipe/drop ALL my data every time I lift Sails (for tests)\n'
+        '1. FOR DEVELOPMENT: '+chalk.bold.cyan('alter')+' - wipe/drop and attempt to re-insert ALL my data (recommended)\n',
+        '2. FOR DEVELOPMENT: '+chalk.bold.yellow('drop')+'  - wipe/drop ALL my data every time I lift Sails (for tests)\n'
+        '3. FOR PRODUCTION: '+chalk.bold.red('safe')+'  - never auto-migrate my database(s). I will do it myself','\n',
       );
       console.log('What would you like Sails to do this time?');
       console.log();
@@ -335,11 +335,11 @@ module.exports = function initialize(hook, sails, done){
 
         switch (result) {
           case 'alter':
-          case '2':
+          case '1':
             sails.config.models.migrate = 'alter';
             break;
           case 'drop':
-          case '3':
+          case '2':
             sails.config.models.migrate = 'drop';
             break;
           default:

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -318,7 +318,7 @@ module.exports = function initialize(hook, sails, done){
         'migrate:"safe" to protect against inadvertent deletion of your data.\n',
         'However during development, you have a few other options for convenience:'+'\n\n',
         '1. FOR DEVELOPMENT: '+chalk.bold.cyan('alter')+' - wipe/drop and attempt to re-insert ALL my data (recommended)\n',
-        '2. FOR DEVELOPMENT: '+chalk.bold.yellow('drop')+'  - wipe/drop ALL my data every time I lift Sails (for tests)\n'
+        '2. FOR DEVELOPMENT: '+chalk.bold.yellow('drop')+'  - wipe/drop ALL my data every time I lift Sails (for tests)\n',
         '3. FOR PRODUCTION: '+chalk.bold.red('safe')+'  - never auto-migrate my database(s). I will do it myself','\n',
       );
       console.log('What would you like Sails to do this time?');

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -308,7 +308,7 @@ module.exports = function initialize(hook, sails, done){
         '(perhaps this is the first time you\'re lifting it with models?)'+'\n',
         '\n',
         'In short, this setting controls whether/how Sails will attempt to automatically'+'\n',
-        'rebuild the tables/collections/sets/etc. in your database schema.\n',
+        'rebuild the tables/collections in your database schema every time you lift.\n',
         'You can read more about the "migrate" setting here:'+'\n',
         'http://sailsjs.com/docs/concepts/models-and-orm/model-settings#?migrate\n'
         // 'command(⌘)+click to open links in the terminal'
@@ -316,10 +316,10 @@ module.exports = function initialize(hook, sails, done){
       console.log('',
         'In a production environment (NODE_ENV==="production") Sails always uses'+'\n',
         'migrate:"safe" to protect against inadvertent deletion of your data.\n',
-        'However during development, you have a few other options for convenience:'+'\n\n',
+        'However '+chalk.bold('during development')+', you have a few different options for convenience:'+'\n\n',
         '1. FOR DEVELOPMENT: '+chalk.bold.cyan('alter')+' - wipe/drop and attempt to re-insert ALL my data (recommended)\n',
-        '2. FOR DEVELOPMENT: '+chalk.bold.yellow('drop')+'  - wipe/drop ALL my data every time I lift Sails (for tests)\n',
-        '3. FOR PRODUCTION: '+chalk.bold.red('safe')+'  - never auto-migrate my database(s). I will do it myself','\n'
+        '2. FOR TESTS: '+chalk.bold.yellow('drop')+'  - wipe/drop ALL my data every time I lift Sails\n',
+        '3. FOR STAGING: '+chalk.bold.red('safe')+'  - never auto-migrate my database(s). I will do it myself','\n'
       );
       console.log('What would you like Sails to do this time?');
       console.log();

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -319,7 +319,7 @@ module.exports = function initialize(hook, sails, done){
         'However during development, you have a few other options for convenience:'+'\n\n',
         '1. FOR DEVELOPMENT: '+chalk.bold.cyan('alter')+' - wipe/drop and attempt to re-insert ALL my data (recommended)\n',
         '2. FOR DEVELOPMENT: '+chalk.bold.yellow('drop')+'  - wipe/drop ALL my data every time I lift Sails (for tests)\n',
-        '3. FOR PRODUCTION: '+chalk.bold.red('safe')+'  - never auto-migrate my database(s). I will do it myself','\n',
+        '3. FOR PRODUCTION: '+chalk.bold.red('safe')+'  - never auto-migrate my database(s). I will do it myself','\n'
       );
       console.log('What would you like Sails to do this time?');
       console.log();


### PR DESCRIPTION
List `alter` first, since it's the most useful for development, and list `safe` last, since it's only needed in production and it's unlikely someone would even be seeing this prompt when they ought to choose that one.