### PR TITLE
Move compatibility check before `buildOntology`

### DIFF
--- a/lib/build-registered-datastore-instance.js
+++ b/lib/build-registered-datastore-instance.js
@@ -10,7 +10,6 @@ var helpLeaseConnection = require('./datastore-method-utils/help-lease-connectio
 var helpSendStatement = require('./datastore-method-utils/help-send-statement');
 var helpSendNativeQuery = require('./datastore-method-utils/help-send-native-query');
 var helpRunTransaction = require('./datastore-method-utils/help-run-transaction');
-var checkAdapterCompatibility = require('./check-adapter-compatibility');
 
 
 /**
@@ -53,14 +52,6 @@ module.exports = function buildRegisteredDatastoreInstance(datastoreName, normal
   // from the underlying adapter-- if the adapter even exposes one in the
   // first place)
   rdi.config = normalizedDatastoreConfig;
-
-  // Verify that this adapter is compatible w/ this version of Sails / Waterline.
-  // (if not, go ahead and throw)
-  checkAdapterCompatibility(datastoreName, adapter);
-  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  // FUTURE: Potentially remove this (^^^) check in favor of its use elsewhere.
-  // For details, see: https://github.com/balderdashy/sails-hook-orm/commit/c32c097efaa20fbddcdc522b6a072d4d2da615ca#commitcomment-21082632
-  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   // Now check whether this adapter is compatible w/ datastore methods in general.
   var genericDoesNotSupportDatastoreMethodsError;

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -14,6 +14,7 @@ var validateModelDef = require('./validate-model-def');
 var buildOntologyAndRunAutoMigrations = require('./build-ontology-and-run-auto-migrations');
 var loadAdapterFromAppDependencies = require('./load-adapter-from-app-dependencies');
 var buildRegisteredDatastoreInstance = require('./build-registered-datastore-instance');
+var checkAdapterCompatibility = require('./check-adapter-compatibility');
 
 
 /**
@@ -385,9 +386,29 @@ module.exports = function initialize(hook, sails, done){
 
     }],
 
+    // Verify that this adapter is compatible w/ this version of Sails / Waterline.
+    // (if not, go ahead and throw)
+    _checkAdapterCompatibility: ['_doubleCheckMigration', function (aaData, next) {
+
+      _.each(aaData._determineRelevantDatastoreNames, function _eachRelevantDatastoreName(datastoreName) {
+
+        // Look up the normalized config for this datastore.
+        var normalizedDatastoreConfig = hook.normalizedDSConfigs[datastoreName];
+
+        // Find the adapter used by this datastore
+        var adapter = hook.adapters[normalizedDatastoreConfig.adapter];
+
+        checkAdapterCompatibility(datastoreName, adapter);
+
+      });
+
+      return next();
+
+    }],
+
     // Once all user model and adapter definitions are loaded
     // and normalized, go ahead and initialize the ORM.
-    _buildOntology: ['_doubleCheckMigration', function (aaData, next) {
+    _buildOntology: ['_checkAdapterCompatibility', function (aaData, next) {
       // If `sails` is already exiting due to previous errors, bail out.
       if (sails._exiting) {
         // This is possible since we are doing asynchronous things in the initialize function,


### PR DESCRIPTION
Before this, attempting to use a pre-1.0 adapter into a Sails 1.0 app would trigger the waterline error "`registerConnection` method must be renamed to `registerDatastore`.

Verified that this works w/ ad-hoc adapters as well.