### PR TITLE
Add model name to model definition errors

### DIFF
--- a/lib/validate-model-def.js
+++ b/lib/validate-model-def.js
@@ -117,6 +117,7 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
   if (!_.isUndefined(normalizedModelDef.autoCreatedAt) || !_.isUndefined(normalizedModelDef.autoUpdatedAt) || !_.isUndefined(normalizedModelDef.autoPK)) {
     throw new Error(
                     '\n-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'+
+                    'In model `' + modelIdentity + '`:\n'+
                     'The `autoCreatedAt`, `autoUpdatedAt` and `autoPK` top-level model settings were removed\n'+
                     'in Sails 1.0. See http://sailsjs.com/docs/concepts/models-and-orm/attributes for info\n'+
                     'on configuring attributes to be timestamps.  For info on changing the primary key of a model,\n'+
@@ -128,6 +129,7 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
   if (!_.isUndefined(normalizedModelDef.types)) {
     throw new Error(
                     '\n-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'+
+                    'In model `' + modelIdentity + '`:\n'+
                     'The `types` model setting was removed in Sails 1.0.  To perform custom validation on\n'+
                     'an attribute, set `validations: { custom: true }` on that attribute.\n'+
                     'See http://sailsjs.com/docs/concepts/models-and-orm/validations for info\n'+


### PR DESCRIPTION
Add model name to model definition errors. 
I had only one model having updateAt: false, and I didn't know what was going on because I didn't remember of having that. Adding the model name to the error would have helped in tracking the issue.