### PR TITLE
Throw an error when a `protected` attribute modifier is in use

### DIFF
--- a/lib/validate-model-def.js
+++ b/lib/validate-model-def.js
@@ -215,7 +215,7 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
                       '\n-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'+
                       'In model `' + modelIdentity + '`:\n'+
                       'The `toJSON` instance method is no longer supported.\n'+
-                      'Instead, please use the `customToJSON` model class method.\n'+
+                      'Instead, please use the `customToJSON` model setting.\n'+
                       'See http://sailsjs.com/docs/concepts/models-and-orm/model-settings for more info.\n'+
                       '-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n');
     }
@@ -226,7 +226,7 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
         '\n-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'+
         'In model `' + modelIdentity + '`:\n'+
         'The `protected` attribute modifier is no longer supported.\n'+
-        'Instead, please use the `customToJSON` model class method to filter out attributes.\n'+
+        'Instead, please use the `customToJSON` model setting to filter out attributes.\n'+
         'See http://sailsjs.com/docs/concepts/models-and-orm/model-settings for more info.\n'+
         '-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n');
     }

--- a/lib/validate-model-def.js
+++ b/lib/validate-model-def.js
@@ -219,6 +219,17 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
                       'See http://sailsjs.com/docs/concepts/models-and-orm/model-settings for more info.\n'+
                       '-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n');
     }
+    
+    // Ignore `protected` attribute modifier
+    if (val.protected) {
+      throw new Error(
+        '\n-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'+
+        'In model `' + modelIdentity + '`:\n'+
+        'The `protected` attribute modifier is no longer supported.\n'+
+        'Instead, please use the `customToJSON` model class method to filter out attributes.\n'+
+        'See http://sailsjs.com/docs/concepts/models-and-orm/model-settings for more info.\n'+
+        '-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n');
+    }
 
     // If the attribute is a function, log a message
     if (_.isFunction(val)) {

--- a/lib/validate-model-def.js
+++ b/lib/validate-model-def.js
@@ -219,7 +219,7 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
                       'See http://sailsjs.com/docs/concepts/models-and-orm/model-settings for more info.\n'+
                       '-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n');
     }
-    
+
     // Ignore `protected` attribute modifier
     if (val.protected) {
       throw new Error(


### PR DESCRIPTION
Throw an error when a `protected` attribute modifier is in use.

Althought it is not a documented feature (at least, I didn't find it...), it is part of the current "stable" release:

https://github.com/balderdashy/waterline/blob/0.12.x/lib/waterline/model/index.js#L105-L126

May be some other safeguard should be added to waterline