### PR TITLE
If an invalid validation rule is added to validations, throw an error

### DIFF
--- a/lib/validate-model-def.js
+++ b/lib/validate-model-def.js
@@ -382,6 +382,15 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
     // Now loop through any validations and verify that they are appropriate for the attribute's type.
     _.each(_.keys(val.validations), function(validation) {
       var rule = VALIDATIONS[validation];
+      if (!rule) {
+        throw new Error(
+          '\n-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'+
+          'In the `' + attributeName + '` attribute of model `' + modelIdentity + '`:\n'+
+          'The `' + validation + '` validation rule is not a supported validation rule.\n'+
+          'Supported validation rules are: \n'+
+          _.keys(VALIDATIONS).reduce(function(a,v){a +=' - ' + v + '\n'; return a;},'') +
+          '-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n');
+      }
       if (!_.contains(rule.expectedTypes, val.type)) {
         throw new Error(
                         '\n-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'+


### PR DESCRIPTION
For example, while testing, I changed from ip, to isIp (lowercase p) and it throwned an error, because isIp was not a ke of the VALIDATIONS array. This way, a proper error is thrown.