### PR TITLE
docs: add missing comma and link to lifecycle hooks

### DIFF
--- a/lib/validate-model-def.js
+++ b/lib/validate-model-def.js
@@ -241,7 +241,7 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
                       'In the `' + attributeName + '` attribute of model `' + modelIdentity + '`:\n'+
                       'Model instance methods are no longer supported in Sails v1.\n'+
                       'Please refactor the logic from this instance method into\n'+
-                      'a static method model method or helper.\n'+
+                      'a static method, model method or helper.\n'+
                       '-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'));
     }
 
@@ -256,7 +256,8 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
                       'In the `' + attributeName + '` attribute of model `' + modelIdentity + '`:\n'+
                       'The `defaultsTo` property can no longer be specified as a function in Sails 1.0.  If you\n'+
                       'need to calculate a value for the attribute before creating a record, try wrapping your\n'+
-                      '`create` logic in a helper (see http://sailsjs.com/docs/concepts/helpers).\n'+
+                      '`create` logic in a helper (see http://sailsjs.com/docs/concepts/helpers) or using a lifecycle\n'+
+                      'hook (see https://sailsjs.com/documentation/concepts/models-and-orm/lifecycle-callbacks#callbacks-on-create).\n'+
                       '-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'));
     }
 


### PR DESCRIPTION
That first change with the comma speak for itself.

I added the link to the lifecycle hooks page too because as a sails n00b, reading the doco for helpers didn't actually tell me how to use a helper to populate the model. I used the `beforeCreate` lifecycle hook for that.