### PR TITLE
[patch] Fix node modules directory path, Remove deprecated lodash aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,12 +12,13 @@
 #
 
 ############################
-# sails / node.js / npm
+# sails / node.js / npm / yarn
 ############################
 node_modules
 .tmp
 npm-debug.log
 package-lock.json
+yarn.lock
 .waterline
 .node_history
 

--- a/.jshintrc
+++ b/.jshintrc
@@ -91,7 +91,7 @@
   // Do NOT allow avant garde use of commas in conditional statements.
   // (this prevents accidentally writing code like:
   //  ```
-  //  if (!_.contains(['+ci', '-ci', '∆ci', '+ce', '-ce', '∆ce']), change.verb) {...}
+  //  if (!_.includes(['+ci', '-ci', '∆ci', '+ce', '-ce', '∆ce']), change.verb) {...}
   //  ```
   //  See the problem in that code?  Neither did we-- that's the problem!)
   "nocomma": true,

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -277,7 +277,7 @@ module.exports = function initialize(hook, sails, done){
             // Look up the referenced datastore for this model, and then check to see if
             // it matches any of the datastores using the sails-disk adapter.
             var referencedDatastore = normalizedModelDef.datastore;
-            if (_.contains(datastoresUsingSailsDisk, referencedDatastore)) {
+            if (_.includes(datastoresUsingSailsDisk, referencedDatastore)) {
               memo.push(identity);
             }
             return memo;

--- a/lib/load-adapter-from-app-dependencies.js
+++ b/lib/load-adapter-from-app-dependencies.js
@@ -41,7 +41,7 @@ module.exports = function loadAdapterFromAppDependencies(adapterPackageName, dat
 
   // Before trying to actually require the adapter, determine the path to the module
   // relative to the app we're loading:
-  var userlandDependenciesPath = Path.resolve(sails.config.appPath, 'node_modules');
+  var userlandDependenciesPath = Path.resolve(process.cwd(), 'node_modules');
   var adapterPackagePath = Path.join(userlandDependenciesPath, adapterPackageName);
 
 

--- a/lib/validate-model-def.js
+++ b/lib/validate-model-def.js
@@ -411,7 +411,7 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
           _.keys(VALIDATIONS).reduce(function(a,v){a +=' - ' + v + '\n'; return a;},'') +
           '-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'));
       }
-      if (!_.contains(rule.expectedTypes, val.type)) {
+      if (!_.includes(rule.expectedTypes, val.type)) {
         throw flaverr({ name: 'userError', code: 'E_INVALID_MODEL_DEF' }, new Error(
                         '\n-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'+
                         'In the `' + attributeName + '` attribute of model `' + modelIdentity + '`:\n'+


### PR DESCRIPTION
- Changed (remaining) instance of
```javascript
path.resolve(sails.config.appPath, 'node_modules');
```
to
```javascript
path.resolve(process.cwd(), 'node_modules');
```

- Switched out removed lodash aliases for the functions they referenced.