### PR TITLE
Update package.json - fix repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mikermcneil/sails-hook-orm.git"
+    "url": "git+https://github.com/balderdashy/sails-hook-orm.git"
   },
   "keywords": [
     "waterline",


### PR DESCRIPTION
package.json repository URL points to `github.com/mikermcneil/sails-hook-orm.git`, updated to point to `github.com/balderdashy/sails-hook-orm.git`