### PR TITLE
fix: docs anchor link

### DIFF
--- a/lib/validate-model-def.js
+++ b/lib/validate-model-def.js
@@ -257,7 +257,7 @@ module.exports = function validateModelDef (originalModelDef, modelIdentity, hoo
                       'The `defaultsTo` property can no longer be specified as a function in Sails 1.0.  If you\n'+
                       'need to calculate a value for the attribute before creating a record, try wrapping your\n'+
                       '`create` logic in a helper (see http://sailsjs.com/docs/concepts/helpers) or using a lifecycle\n'+
-                      'hook (see https://sailsjs.com/documentation/concepts/models-and-orm/lifecycle-callbacks#callbacks-on-create).\n'+
+                      'hook (see https://sailsjs.com/documentation/concepts/models-and-orm/lifecycle-callbacks#?callbacks-on-create).\n'+
                       '-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-\n'));
     }
 


### PR DESCRIPTION
Happy to contribute to the Sails.js ecosystem with a very tiny small PR.

While I was migrating from Sails.js 0.12.14 to 1+, I noticed the following error message:

> The `defaultsTo` property can no longer be specified as a function in Sails 1.0.  If you
need to calculate a value for the attribute before creating a record, try wrapping your
`create` logic in a helper (see http://sailsjs.com/docs/concepts/helpers) or using a lifecycle
hook (see https://sailsjs.com/documentation/concepts/models-and-orm/lifecycle-callbacks#callbacks-on-create).

I tried to go to the link:

> https://sailsjs.com/documentation/concepts/models-and-orm/lifecycle-callbacks#callbacks-on-create

But it redirected me to a 404 page, then I noticed the link was wrong.