### PR TITLE
Bump up version of prompt to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chalk": "1.1.3",
     "flaverr": "^1.8.0",
     "parley": "^3.3.2",
-    "prompt": "1.1.0",
+    "prompt": "1.2.1",
     "sails-disk": "^2.0.0",
     "waterline": "^0.15.0",
     "waterline-utils": "^1.0.0"


### PR DESCRIPTION
Please upgrade to v1.2.1 for Prompt: https://github.com/flatiron/prompt/commit/b554b310c0d4bb965ddfa20830cff15f4f1120f2

It pinned [colors](https://github.com/Marak/colors.js) dependency to 1.4.0.

Issue: The author of https://github.com/Marak/colors.js has pushed a rogue commit on the newest version which causes garbage to be printed in the console and an infinite loop.

News: https://snyk.io/blog/open-source-npm-packages-colors-faker/
