### PR TITLE
Add adapter reloading when using different instances of sails

### DIFF
--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -123,7 +123,7 @@ module.exports = function initialize(hook, sails, done){
               try {
                 // Otherwise, we'll try and load it as a dependency from the app's `node_modules/` folder,
                 // and also validate and normalize it.
-                hook.adapters[datastoreConfig.adapter] = loadAdapterFromAppDependencies(datastoreConfig.adapter, datastoreName, sails);
+                hook.adapters[datastoreConfig.adapter] = loadAdapterFromAppDependencies(datastoreConfig.adapter, datastoreName, sails, !(datastoreConfig.adapter in hook.adapters));
               } catch (e) {
                 // Special case -- the default adapter will load the sails-disk bundled with sails-hook-orm if it's not installed locally.
                 if (datastoreName === 'default' && datastoreConfig.adapter === 'sails-disk' && e.code === 'E_ADAPTER_NOT_INSTALLED') {

--- a/lib/load-adapter-from-app-dependencies.js
+++ b/lib/load-adapter-from-app-dependencies.js
@@ -27,7 +27,7 @@ var couldNotLoadAdapterError = require('../constants/could-not-load-adapter.erro
  * @throws {Error} E_ADAPTER_NOT_COMPATIBLE
  */
 
-module.exports = function loadAdapterFromAppDependencies(adapterPackageName, datastoreIdentity, sails) {
+module.exports = function loadAdapterFromAppDependencies(adapterPackageName, datastoreIdentity, sails, reloadAdapter) {
 
   //  ╦  ╔═╗╔═╗╔╦╗  ╔═╗╔╦╗╔═╗╔═╗╔╦╗╔═╗╦═╗
   //  ║  ║ ║╠═╣ ║║  ╠═╣ ║║╠═╣╠═╝ ║ ║╣ ╠╦╝
@@ -48,6 +48,16 @@ module.exports = function loadAdapterFromAppDependencies(adapterPackageName, dat
   // Now try to require the adapter from userland dependencies (node_modules of the sails app).
   var adapter;
   try {
+    // This is a work around so we don't have to modify each adapter interface. By default, NodeJS
+    // module system requires files with a cache. Because of that, each adapter will be a Singleton
+    // so we can't have two instances of Sails using the same adapter, making Sails unuseful for
+    // multi-same-technology-databases.
+    // The ideal solution would be that adapters export a function instead of an object, so each
+    // adapter can choose what to cache and what not. But that will imply a breaking change in all
+    // the adapters interfaces.
+    if (reloadAdapter) {
+      delete require.cache[require.resolve(adapterPackagePath)];
+    }
     adapter = require(adapterPackagePath);
   } catch (e) {
     // If there was a problem loading the adapter,


### PR DESCRIPTION
Hi! 👋 
      
Firstly, thanks for your work on this project! 🙂

Today I used [patch-package](https://github.com/ds300/patch-package) to patch `sails-hook-orm@4.0.2` for the project I'm working on and it works successfully.

I was trying to use two different instances of Sails to programmatically port some data from one database to another (same database technology but different clusters).

```javascript
const sails1 = new Sails();
const sails2 = new Sails();
sails1.load(/* database configuration 1 */)
sails2.load(/* database configuration 2 */) // <-- ORM fails here since adapter is already registered

// Make data relocation
```
